### PR TITLE
put highlight-start/end on their own lines

### DIFF
--- a/docs/docs/client-data-fetching.md
+++ b/docs/docs/client-data-fetching.md
@@ -186,11 +186,13 @@ class ClientFetchingExample extends Component {
             <p>Oh noes, error fetching pupper :(</p>
           )}
         </div>
-       </div> {/* highlight-end */}
+        {/* highlight-end */}
+       </div>
     )
   }
 
-  // This data is fetched at run time on the client. // highlight-start
+  // highlight-start
+  // This data is fetched at run time on the client.
   fetchRicksPupper = () => {
     this.setState({ loading: true })
 
@@ -215,7 +217,8 @@ class ClientFetchingExample extends Component {
         this.setState({ loading: false, error })
       })
   }
-} // highlight-end
+}
+// highlight-end
 
 export default ClientFetchingExample
 ```


### PR DESCRIPTION
The highlight processing is causing highlight-start/end to replace the entire line (code included).
There is probably a better way to fix this upstream, but this should allow a direct copy/paste to work.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
